### PR TITLE
Update aws-properties-codepipeline-pipeline-artifactstore-encryptionk…

### DIFF
--- a/doc_source/aws-properties-codepipeline-pipeline-artifactstore-encryptionkey.md
+++ b/doc_source/aws-properties-codepipeline-pipeline-artifactstore-encryptionkey.md
@@ -26,7 +26,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 
 `Id`  <a name="cfn-codepipeline-pipeline-artifactstore-encryptionkey-id"></a>
 The ID used to identify the key\. For an AWS KMS key, you can use the key ID, the key ARN, or the alias ARN\.  
-Aliases are recognized only in the account that created the customer master key \(CMK\)\. For cross\-account actions, you can only use the key ID or key ARN to identify the key\.
+Aliases are recognized only in the account that created the customer master key \(CMK\)\. For cross\-account actions, you can use the key ARN to identify the key\.
 *Required*: Yes  
 *Type*: String  
 *Update requires*: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)


### PR DESCRIPTION
…ey.md

When you use the KMS Key ID, you will have failures with CodeBuild when it tries to upload the artifact back to the artifact store.  It will look for the key in its own account and will not find the key and result in:
CLIENT_ERROR: Error in UPLOAD_ARTIFACTS phase: KMS.NotFoundException: Key 'arn:aws:kms:us-east-1:<obscured>:key/<obscured>' does not exist status code: 400, request id: <obscured>, host id: <obscured>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
